### PR TITLE
ST-3296: migrate to semaphore 2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,11 +7,6 @@ agent:
 blocks:
   - name: "Build, Test, Release"
     task:
-      env_vars:
-        # Set maven to use a local directory. This is required for
-        # the cache util. It must be set in all blocks.
-        - name: SEMAPHORE_TRIGGER_SOURCE
-          value: push
       secrets:
         - name: semaphore-secrets-global
         - name: artifactory-docker-helm
@@ -21,12 +16,9 @@ blocks:
         - name: netrc
         - name: ssh_config
         - name: gitconfig
-        - name: maven-settings
-        - name: netrc
       prologue:
         commands:
-          - sem-version go 1.9
-          - sem-version java 8
+          - sem-version go 1.12
           - 'export "GOPATH=$(go env GOPATH)"'
           - 'export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"'
           - 'export "PATH=${GOPATH}/bin:${PATH}"'

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ commit-release:
 	git commit -m "$(BUMPED_VERSION): $(BUMP) version bump [ci skip]"
 
 deps:
-	@which golint 2>/dev/null || go get -u github.com/golang/lint/golint
+	@which golint 2>/dev/null || go get -u golang.org/x/lint/golint
 
 coverage:
       ifdef CI
@@ -79,8 +79,10 @@ coverage:
       endif
 
 test:
+ifndef CI
 	#This is broken on sem2 / go 1.9
-	#@gofmt -w .
+	@gofmt -w .
+endif
 	@golint -set_exit_status `go list ./... | grep -v /vendor/`
 	@go vet ./...
 	@make coverage


### PR DESCRIPTION
- add semaphore config 
- disable gofmt due to issue with 1.9 / gofmt command missing
