### PR TITLE
DP-6574 - Upgrade Go, M1 Support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,7 @@ blocks:
           - . vault-sem-get-secret gitconfig
           - chmod 400 ~/.ssh/id_rsa
           - make init-ci
-          - sem-version go 1.12
+          - sem-version go 1.16.15
           - 'export "GOPATH=$(go env GOPATH)"'
           - 'export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/confluentinc/${SEMAPHORE_PROJECT_NAME}"'
           - 'export "PATH=${GOPATH}/bin:${PATH}"'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/confluentinc/go-editor
 
-go 1.12
+go 1.16


### PR DESCRIPTION
# Background
The DevProd team along with many others are working to make sure [developers can develop on M1 MacBooks](https://confluentinc.atlassian.net/browse/DP-5615). This repository is using a version of Golang that [does not have native arm64](https://confluentinc.atlassian.net/browse/DP-6574) support and is no longer supported in general.

Each major Go release is supported [until there are two newer major releases](https://go.dev/doc/devel/release#policy).
As Golang 1.18 has been released this version is no longer supported and as such is not receiving security updates, and M1 support won't be backported.
Additionally, each major Golang release includes performance improvements that this service will likely benefit from.

**This updates Go to 1.16.15 to natively support M1 development.**

# Changelog
As one would expect with updating a major versions, there may be breaking changes. However Golang has a strong compatibility guarantee within the 1.x releases.
With that said, the release notes for each version can be reviewed here: https://go.dev/doc/devel/release

# Migration Changes
This automated pull request changes
* .go-version
* .semaphore/semaphore.yml
* Dockerfile
* go.mod
* go.sum (via `go mod tidy`)


# Actions
* If you are happy with the changes, feel free to merge.
* If you have concerns about the changes, comment on this pull request, tagging the Developer Productivity team (@confluentinc/tools).
* If you happen to have time to look at any of the failures and can help us out, that would be greatly appreciated.
* If the CI does not pass, we may fix some simpler issues on this pull request, but if there is a deeper problem associated with the upgrade, we may create a task for your team to fix.
