### PR TITLE
DP-9370 - use cc-service-bot to manage Semaphore project

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: go-editor
-lang: unknown
-lang_version: unknown
+lang: go
+lang_version: 1.16.15
 git:
   enable: true
 github:
@@ -8,8 +8,3 @@ github:
   repo_name: confluentinc/go-editor
 semaphore:
   enable: true
-  pipeline_enable: false
-  triggers:
-  - tags
-  - branches
-  branches: []


### PR DESCRIPTION
# Background
Currently, some existing Semaphore projects were created manually via the Semaphore UI.
[cc-service-bot](https://github.com/confluentinc/cc-service-bot) is a tool for managing Semaphore projects via code (amongst other things).
Refer to [the user guide](https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2870285870/Service+Bot+User+Guide) for more information.
The DevProd team is migrating all Semaphore projects, which are not currently managed by `cc-service-bot`, to be managed by `cc-service-bot`.

# Migration Changes
This automated pull request changes
* Service YAML file, `service.yml`

# Rationales for argument values
The configuration here was selected based upon the settings of the existing Semaphore project. This configuration matches the existing project where possible. If desired, you can change the configuration to match your team's other repos. It was decided that it was more likely that you would like to maintain the existing settings for a project than conform to other projects you may own. It was impossible to have a one size fits all approach that would work for the migration tooling because different teams want different things.
* `lang` and `lang_version` are set to `unknown` because they are required by `cc-service-bot`. However, they are not used in this use case. They would only be used if you had `pipeline_enable: true` (or omitted it). In that case, these arguments would be passed to sem-version in the `.semaphore/semaphore.yml` file.
* `git.enable` is set to `true` because it results in the generated Semaphore project configuration to be committed to the repo under `.semaphore/project.yml`. Whether this is enabled or not, the same project gets generated. Additionally, it implies to auto-commit changes rather than leaving them stashed for engineers to commit manually. This basically separates the various plugins' updates into logical commits instead of lumping them together into a single commit to parse. Docs:
  * https://confluentinc.atlassian.net/wiki/spaces/Foundations/pages/2870740796/Add+Git+and+Git+Hooks
  * https://github.com/confluentinc/cc-service-bot/blob/master/plugin_git.py#L4
* `pipeline_enable` is set to `false` because if it is set to `true`, then `cc-service-bot` will modify the `.semaphore/semaphore.yml` file to match the standard implementation. Since the existing project was implemented manually, it is assumed that this differs from the `cc-service-bot` design, and we wouldn't want to overwrite it.
* `triggers` is set based upon your existing project's settings. The default behavior for the `cc-service-bot` is `['branches', 'tags', 'pull_requests']`. If that is what you would like for this project, then you should delete the `triggers` parameter.
* `branches` is set based upon your existing project's settings. The default behavior for the `cc-service-bot` is `['master', 'main', '/^v\\d+\\.\\d+\\.x$/']`. If that is what you would like for this project, then you should delete the `branches` parameter. Note that `[]` means workflows are triggered for all branches.

# Actions
* If you are happy with the changes, please merge them.
* If you have concerns about the changes, either modify the pull request directly or comment on this pull request, tagging the Developer Productivity team `(@confluentinc/tools)`.
